### PR TITLE
Remove jcip-annotations dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
         <log4j.version>2.23.1</log4j.version> <!-- Slf4j implementation -->
         <graalvm.version>24.0.1</graalvm.version> <!-- ScriptEngine implementation -->
         <yamlbeans.version>1.17</yamlbeans.version> <!-- Config file -->
-        <jcip-annotations.version>1.0</jcip-annotations.version> <!-- Annotations for concurrency documentation -->
         <HikariCP.version>5.1.0</HikariCP.version> <!-- Database connection pool -->
         <mysql-connector-j.version>8.3.0</mysql-connector-j.version> <!-- MySQL JDBC driver -->
         <junit.version>5.10.1</junit.version> <!-- Unit test -->
@@ -36,11 +35,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>net.jcip</groupId>
-            <artifactId>jcip-annotations</artifactId>
-            <version>${jcip-annotations.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>

--- a/src/main/java/scripting/SynchronizedInvocable.java
+++ b/src/main/java/scripting/SynchronizedInvocable.java
@@ -3,14 +3,11 @@ package scripting;
 import javax.script.Invocable;
 import javax.script.ScriptException;
 
-import net.jcip.annotations.ThreadSafe;
-
 /**
  * Thread safe wrapper around Invocable.
  * Thread safety is achieved by synchronizing all methods.
  * Needed to get around the restriction that GraalVM imposes on evaluated scripts: no concurrent access allowed.
  */
-@ThreadSafe
 public class SynchronizedInvocable implements Invocable {
     private final Invocable invocable;
 


### PR DESCRIPTION
The @ThreadSafe annotation was purely documentary with no runtime effect. The class javadoc already documents the thread-safety contract.