### PR TITLE
Fix renovate to use PR-based automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,12 @@
   "extends": [
     "config:recommended"
   ],
+  "platformAutomerge": true,
   "packageRules": [
     {
       "matchManagers": ["maven"],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "pr"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Explicitly set `automergeType: "pr"` so Renovate always creates PRs instead of pushing directly
- Enable `platformAutomerge` to use GitHub's native auto-merge, which waits for required status checks (the Docker build) before merging

## Test plan
- [ ] Verify next Renovate run creates a PR instead of pushing to main
- [ ] Confirm PR triggers the `build` workflow and auto-merges after it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)